### PR TITLE
references #5, basescript supports extensions

### DIFF
--- a/basescript/__init__.py
+++ b/basescript/__init__.py
@@ -1,1 +1,14 @@
 from basescript import BaseScript
+
+ENTRY_POINT = "basescript.extensions"
+try:
+    from pkg_resources import iter_entry_points
+except ImportError:
+    pass
+else:
+    # adding all extensions here
+    for ep in iter_entry_points(ENTRY_POINT):
+        extension_class = ep.load()
+        # add only those that are subclasses of BaseScript
+        if issubclass(extension_class, BaseScript):
+            globals()[ep.name] = extension_class


### PR DESCRIPTION
added entry point basescript.extensions

Basescript can be extended by creating other modules that have a class that subclass BaseScript. And includes it in the "basescript.extensions" under "entry_points" in setup.py
