### PR TITLE
fixes #29, stats support for boolean and None

### DIFF
--- a/basescript/stats.py
+++ b/basescript/stats.py
@@ -81,12 +81,13 @@ class Series(object):
         """
         creates the key to make a series
         a series is a combination of retention policy, measurement and tags
+        NOTE: ignores tags who's values are None
         """
         # TODO include retention policy in the series key creation ?
         if len(tags) == 0:
             return measurement
 
-        tags_srtd = sorted([ '%s=%s' % (k,v) for k,v in tags.iteritems() ])
+        tags_srtd = sorted([ '%s=%s' % (k,v) for k,v in tags.iteritems() if v is not None ])
         tags_str = ','.join(tags_srtd)
         # TODO if relying on this format later, make sure k,v do not have spaces or commas
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -88,6 +88,20 @@ class TestSeries(unittest.TestCase):
         expected = "my_measurement,alpha_tag=xyz,beta=aaa,mytag1=abcd,mytag2=defg,num_tag=123"
         self.assertEqual(series_key, expected)
 
+    def test_gen_series_key_with_tag_value_none(self):
+        series_key = basescript.stats.Series.make_series_key("my_measurement",
+            mytag1="abcd", mytag2=None, mytag3="xyz",
+        )
+        expected = "my_measurement,mytag1=abcd,mytag3=xyz"
+        self.assertEqual(series_key, expected)
+
+    def test_gen_series_key_with_tag_value_false(self):
+        series_key = basescript.stats.Series.make_series_key("my_measurement",
+            mytag1="abcd", mytag2=False, mytag3="xyz",
+        )
+        expected = "my_measurement,mytag1=abcd,mytag2=False,mytag3=xyz"
+        self.assertEqual(series_key, expected)
+
     def _test_last_accessed_times_in_non_decreasing_order(self, lats):
         # all the last_accessed_times must be in increasing order starting with None
         for i in xrange(0, len(lats) - 1):


### PR DESCRIPTION
tags who's value is None are ignored.
tags who's value is True/False are kept.