### PR TITLE
fixes #33, no-op logger when user silences logs

### DIFF
--- a/basescript/utils.py
+++ b/basescript/utils.py
@@ -1,0 +1,9 @@
+class Dummy(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __getattr__(self, *args, **kwargs):
+        return self

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_long_description():
 
 long_description = get_long_description()
 
-version = '0.1.9'
+version = '0.1.10'
 setup(
     name="basescript",
     version=version,


### PR DESCRIPTION
when the user passes --quiet without specifying a --log-file,
there is no need to ever process log statements.
a no-op dummy object acts as a log.

connected to #33 
closes #33 