### PR TITLE
references #106, on receiveding SIGUSR1, reopening log file to enable…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_long_description():
 
 long_description = get_long_description()
 
-version = "0.3.7"
+version = "0.3.8"
 setup(
     name="basescript",
     version=version,


### PR DESCRIPTION
… external log rotation tools to work

This fix ensures that when an external log rotation tool such as `logrotate` renames the current log file, it can inform the basescript based process by sending a SIGUSR1 signal. Upon receipt, basescript will now close the currently open log file and reopen it. This ensures that newly written log lines after the file move don't continue to go into the renamed file but instead to a file with the original file name.