### PR TITLE
Support for custom global env variables 

### DIFF
--- a/basescript/basescript.py
+++ b/basescript/basescript.py
@@ -4,7 +4,7 @@ import sys
 import argparse
 import socket
 
-from .log import init_logger, pretty_print
+from .log import init_logger, pretty_print, ReadEnv
 from deeputil import Dummy
 
 
@@ -58,6 +58,8 @@ class BaseScript(object):
 
         self._flush_metrics_q = log._force_flush_q
         self.log = log.bind(name=self.args.name)
+
+        ReadEnv(self.args.env_file)
 
         self.stats = Dummy()
 
@@ -173,6 +175,11 @@ class BaseScript(object):
             default=False,
             action="store_true",
             help="Hide log keys such as id, host",
+        )
+        parser.add_argument(
+            "--env-file",
+            default=None,
+            help="Writes logs to log file if specified, default: %(default)s",
         )
 
     def define_args(self, parser):

--- a/basescript/basescript.py
+++ b/basescript/basescript.py
@@ -59,7 +59,8 @@ class BaseScript(object):
         self._flush_metrics_q = log._force_flush_q
         self.log = log.bind(name=self.args.name)
 
-        ReadEnv(self.args.env_file)
+        if self.args.env_file:
+            ReadEnv(self.args.env_file)
 
         self.stats = Dummy()
 

--- a/basescript/log.py
+++ b/basescript/log.py
@@ -180,7 +180,8 @@ class BoundLevelLogger(structlog.BoundLoggerBase):
         f = sys._getframe()
         level_method_frame = f.f_back
         caller_frame = level_method_frame.f_back
-        event_dict.update(self.env_context)
+        if hasattr(self, "env_context"):
+            event_dict.update(self.env_context)
         return event_dict
 
     def debug(self, event=None, *args, **kw):

--- a/basescript/log.py
+++ b/basescript/log.py
@@ -7,6 +7,7 @@ import socket
 import logging
 import numbers
 import signal
+import yaml
 from six.moves import queue
 from threading import Thread, Lock
 from datetime import datetime
@@ -67,6 +68,22 @@ class FileWrapper:
         with self.lock:
             self.f.close()
             self.f = open(self.fpath, "a")
+
+
+class ReadEnv:
+    def __init__(self, envfile):
+        self.envfile = envfile
+        self.env = self.read()
+        setattr(structlog.BoundLoggerBase, "env_context", self.env)
+        signal.signal(signal.SIGUSR1, self.__sighandler__)
+
+    def read(self):
+        with open(self.envfile) as f:
+            return yaml.full_load(f.read())
+
+    def __sighandler__(self, signum, frame):
+        self.env = self.read()
+        setattr(structlog.BoundLoggerBase, "env_context", self.env)
 
 
 class StderrConsoleRenderer(object):
@@ -163,6 +180,7 @@ class BoundLevelLogger(structlog.BoundLoggerBase):
         f = sys._getframe()
         level_method_frame = f.f_back
         caller_frame = level_method_frame.f_back
+        event_dict.update(self.env_context)
         return event_dict
 
     def debug(self, event=None, *args, **kw):

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "structlog==18.1.0",
         "colorama==0.3.9",
         "deeputil>=0.2.7",
+        "PyYAML==5.1.1"
     ],
     package_dir={"basescript": "basescript"},
     packages=find_packages(".", exclude=["tests*"]),

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_long_description():
 
 long_description = get_long_description()
 
-version = "0.3.8"
+version = "0.3.9"
 setup(
     name="basescript",
     version=version,


### PR DESCRIPTION
# summary
- Added support to accept env variables from the command line argument
- env file will contain a dictionary 

**example env file**
```yaml
# Github run id
session_id : 123456789
# hostname of the hetzner cloud machine
hostname: 1234-4567-7123
```
- whenever there's a change in the env file user have to issue a usr1 signal to update env variables

**test_script.py**
```python3
from basescript import BaseScript
from time import sleep


class HelloWorld(BaseScript):
    def run(self):
        for _ in range(100000):
            self.log.info("test_env_file_{}".format(_))
            sleep(1)


if __name__ == "__main__":
    HelloWorld().start()
```
**run command**

```bash
python3 test_script.py --log-level DEBUG --log-file  log.log --env-file env.yaml run
```
- type below command to get process id

```bash
ps aux | grep -i test_script.py
```
- Send kill signal to the process 
```bash
kill -s USR1 <PID>
``` 


**refers to**
- refers to #108 and  https://github.com/nudjur/infra/issues/307
- updated version 